### PR TITLE
[BugFix] Allow editing of profile.playing

### DIFF
--- a/client/views/common/header.html
+++ b/client/views/common/header.html
@@ -22,7 +22,6 @@
         <ul class="nav navbar-nav">
           <li class="{{ isActivePath 'playlists' }}"><a href="{{pathFor 'playlists'}}">Playlists</a></li>
           <li class="{{ isActivePath 'loved'     }}"><a href="{{pathFor 'loved'}}">Loved songs</a></li>
-          <li class="{{ isActivePath 'friends'   }}"><a href="{{pathFor 'friends'}}">Friends</a></li>
           <li>
             <a rel="external" href="https://github.com/Rayman/fusic-meteor/issues?state=open">
               <span class="glyphicon glyphicon-exclamation-sign"> </span>Report Issue

--- a/collections.js
+++ b/collections.js
@@ -48,7 +48,8 @@ UserProfile = new SimpleSchema({
     },
     playing: {
       optional:true,
-      type: [Object]
+      type: Object,
+      blackbox:true,
     }
     
     


### PR DESCRIPTION
Simpleschema didn't work correctly, so playing songs doesn't work right now .. Oops!
This fix allows profile.playing variables to be edited without simpleShema monitoring. 
The blackbox parameter allows for a more flexible use of the profile.playing variable, so we can continue to experiment with the player without breaking the schema.
