### PR TITLE
Fix crashing Youtube Player on navigation

### DIFF
--- a/client/views/common/footer.js
+++ b/client/views/common/footer.js
@@ -1,13 +1,14 @@
 // * * * * * * * * * * * * * * * PLAYER TEMPLATE CALLBACKS  * * * * * * * * * * * * * *
 
-Template.player.created = function() {
-  Session.set('youtubePlayerInitialized', false);
-};
-
 Template.player.rendered = function() {
+  
   if (Session.equals('youtubePlayerInitialized', false)) {
     $.getScript('https://www.youtube.com/iframe_api', function () {});
   }
+  if($('div#youtube-embed').length == 1 && YT.loaded==1) { //if placeholder is (still) in place and YT api is available, re-init player
+    initPlayer();
+  }
+
 
   var isDragging = false;
 
@@ -44,23 +45,26 @@ Template.player.rendered = function() {
       isDragging = false;
       $(window).unbind("mousemove");
   });
-};
+}
 
 // * * * * * * * * * * * * * * * YOUTUBE IFRAME PLAYER INITIALIZATION  * * * * * * * * * * * * * *
 
+Session.set('youtubePlayerInitialized', false);
 youtubePlayer=null;
-onYouTubeIframeAPIReady = function() {
+initPlayer = function() {
   youtubePlayer = new YT.Player('youtube-embed', {
     height: '480',
     width: '640',
-    videoId: 'M7lc1UVf-VE',
+    videoId: '',
     events: {
       'onReady': onPlayerReady,
       'onStateChange': onPlayerStateChange
     }
   });
   Session.set('youtubePlayerInitialized', true);
-};
+}
+onYouTubeIframeAPIReady = initPlayer;
+
 
 //  * * * * * * * * * * * * * * Callbacks  * * * * * * * * * * * * * *
 


### PR DESCRIPTION
Fixes #67 
It still needs some extra attention though, it looks like the complete footer view re renders on navigation, which is not supposed to happen in the first place. 
It should be like navigating between non-playlist pages currently is (the music just continues to play, nothing re-renders)
